### PR TITLE
Improve docker compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
 # Xpense
 
-To start the server, run following command:
+## Server
+The server code is located in the `Xpense Server` directory.
+Before starting it you might want to change the variables in the `"Xpense Server"/.env` file.
 
-1. vapor run migrate
+### Start the server locally
+To start the server locally, run following command:
 
-2. vapor run serve
+1. `cd Xpense Server` to go to the server code directory
+2. `vapor run migrate` to migrate the database (only needs to be done once)
+3. `vapor run serve` to start the server
+
+### Start the server with Docker (compose)
+To start the server with Docker you can run the following commands:
+1. `cd Xpense Server` to go to the server code directory
+2. `docker compose build app` to build the vapor application
+3. `docker compose up -d` to start the database and vapor application
+4. `docker compose run migrate` to migrate the database (you have to wait until the database is availabe)
+5. `docker compose logs -f` to see the output of all services
+6. `docker compose logs -f app` to see only the output of the vapor application
+7. `docker compose down` to stop all services

--- a/Xpense Server/.env
+++ b/Xpense Server/.env
@@ -1,0 +1,5 @@
+LOG_LEVEL="${LOG_LEVEL:-debug}"
+DATABASE_HOST='db'
+DATABASE_NAME='vapor_database'
+DATABASE_USERNAME='vapor_username'
+DATABASE_PASSWORD='vapor_password'

--- a/Xpense Server/Dockerfile
+++ b/Xpense Server/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:5.7-jammy as build
+FROM swift:5.7.2-jammy as build
 
 # Install OS updates and, if needed, sqlite3
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \

--- a/Xpense Server/docker-compose.yml
+++ b/Xpense Server/docker-compose.yml
@@ -8,33 +8,21 @@
 #
 # Learn more: https://docs.docker.com/compose/reference/
 #
-#   Build images: docker-compose build
-#      Start app: docker-compose up app
-# Start database: docker-compose up db
-# Run migrations: docker-compose run migrate
-#       Stop all: docker-compose down (add -v to wipe db)
-#
 version: '3.7'
 
 volumes:
   db_data:
-
-x-shared_environment: &shared_environment
-  LOG_LEVEL: ${LOG_LEVEL:-debug}
-  DATABASE_HOST: db
-  DATABASE_NAME: vapor_database
-  DATABASE_USERNAME: vapor_username
-  DATABASE_PASSWORD: vapor_password
   
 services:
   app:
     image: xpense-server:latest
     build:
       context: .
-    environment:
-      <<: *shared_environment
+    env_file:
+      - ./.env
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - '8080:8080'
     # user: '0' # uncomment to run as root for testing purposes even though Dockerfile defines 'vapor' user.
@@ -43,32 +31,40 @@ services:
     image: xpense-server:latest
     build:
       context: .
-    environment:
-      <<: *shared_environment
+    env_file:
+      - ./.env
     depends_on:
-      - db
-    command: ["migrate", "--yes"]
+      db:
+        condition: service_healthy
+    command: ["migrate", "--yes", "--env", "production"]
     deploy:
       replicas: 0
   revert:
     image: xpense-server:latest
     build:
       context: .
-    environment:
-      <<: *shared_environment
+    env_file:
+      - ./.env
     depends_on:
-      - db
-    command: ["migrate", "--revert", "--yes"]
+      db:
+        condition: service_healthy
+    command: ["migrate", "--revert", "--yes", "--env", "production"]
     deploy:
       replicas: 0
   db:
-    image: postgres:14-alpine
+    image: postgres:15-alpine
     volumes:
       - db_data:/var/lib/postgresql/data/pgdata
     environment:
       PGDATA: /var/lib/postgresql/data/pgdata
-      POSTGRES_USER: vapor_username
-      POSTGRES_PASSWORD: vapor_password
-      POSTGRES_DB: vapor_database
+      POSTGRES_USER: $DATABASE_USERNAME
+      POSTGRES_PASSWORD: $DATABASE_PASSWORD
+      POSTGRES_DB: $DATABASE_NAME
+    healthcheck:
+      test: pg_isready
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 30s
     ports:
       - '5432:5432'


### PR DESCRIPTION
## Motivation
The docker compose setup had some issues and could also be improved. From Slack:
1. The documentation for running the docker-compose.yml should also be in the README, as the fact that you need to run the migration manually might be overlooked otherwise.
2. The docker compose documentation uses the deprecated “docker-compose” command. docker compose is the new command to use the new and supported plugin
3. The docker compose up commands in the documentation should probably use the detached mode, as running more than one service would currently require multiple terminal tabs. Maybe also add another comment here for docker compose logs -f
4. The used Postgres image is outdated. It uses 14, but 15 is the newest.
5. Currently, the database credentials are specified at two points in the config. This could be improved by adding e.g. a .env file
6. On my (amd64) Debian server I had to change the build image from swift:5.7-jammy to swift:5.7.2-jammy , as it would otherwise throw an error. Might be something limited to my server though, as this is not required on my (arm64) MacBook.
7. The migrations don’t use the production environment, so they are never applied to the Postgres Database

## Description
I addressed all points:
1. Moved and expanded
2. Change
3. Added
4. Changed
5. Added .env file and used that instead. Added documentation in README
6. Not super necessary, but still changed it
7. Fixed

## Disclaimer
There still exists another issue with the migrations and Postgres. This prevents the successful execution of the migrations. This was not fixed in this PR.