### PR TITLE
Fix server migrations

### DIFF
--- a/Xpense Server/Sources/App/Models/Account.swift
+++ b/Xpense Server/Sources/App/Models/Account.swift
@@ -44,7 +44,6 @@ extension Account {
                 .id()
                 .field("name", .string, .required)
                 .field("user_id", .uuid, .required, .references("users", "id"))
-                .field("transactions", .array(of: .uuid), .references("transactions", "id"))
                 .create()
         }
         

--- a/Xpense Server/Sources/App/Models/User.swift
+++ b/Xpense Server/Sources/App/Models/User.swift
@@ -61,7 +61,6 @@ extension User {
                 .id()
                 .field("username", .string, .required)
                 .field("password_hash", .string, .required)
-                .field("accounts", .array(of: .uuid), .references("accounts", "id"))
                 .create()
         }
         


### PR DESCRIPTION
## Motivation
The server migrations did not work when using Postgres.

## Description
This was caused by wrong migration fields for the User and Account models. They each specified an array of UUIDs as a field and set it as a Foreign Key, which is a. against the third normal form and also obviously breaks when using a proper relational database.
I removed those two fields and it works now. 