### PR TITLE
Refactor Model to accommodate concurrency exercises

### DIFF
--- a/XpenseModel/Sources/XpenseModel/MockModel/MockModel.swift
+++ b/XpenseModel/Sources/XpenseModel/MockModel/MockModel.swift
@@ -88,11 +88,11 @@ public class MockModel: Model {
         self.init(user: user, accounts: accounts, transactions: transactions)
     }
 
-    public override func refreshAccounts() async throws -> [Account] {
+    override func loadAccounts() async throws -> [Account] {
         accounts
     }
 
-    public override func refreshTransactions() async throws -> [Transaction] {
+    override func loadTransactions() async throws -> [Transaction] {
         transactions
     }
 }

--- a/XpenseModel/Sources/XpenseModel/MockModel/MockModel.swift
+++ b/XpenseModel/Sources/XpenseModel/MockModel/MockModel.swift
@@ -87,4 +87,12 @@ public class MockModel: Model {
         
         self.init(user: user, accounts: accounts, transactions: transactions)
     }
+
+    public override func refreshAccounts() async throws -> [Account] {
+        accounts
+    }
+
+    public override func refreshTransactions() async throws -> [Transaction] {
+        transactions
+    }
 }

--- a/XpenseModel/Sources/XpenseModel/RestfulModel/Restful.swift
+++ b/XpenseModel/Sources/XpenseModel/RestfulModel/Restful.swift
@@ -35,7 +35,11 @@ protocol Restful: Codable & Identifiable & Comparable {
 // MARK: Restful
 extension Restful where Self.ID == UUID? {
     static func get() async throws -> [Self] {
-        try await NetworkManager.getElements(on: Self.route)
+        do {
+            return try await NetworkManager.getElements(on: Self.route)
+        } catch {
+            throw XpenseServiceError.loadingFailed(Self.self)
+        }
     }
     
     

--- a/XpenseModel/Sources/XpenseModel/RestfulModel/RestfulModel.swift
+++ b/XpenseModel/Sources/XpenseModel/RestfulModel/RestfulModel.swift
@@ -15,9 +15,9 @@ import Foundation
 @available(iOS 16.0, *)
 public class RestfulModel: Model {
     /// The base route that is used to access the RESTful server
-    static var baseURL: URL = {
+    static let baseURL: URL = {
         guard let baseURL = URL(string: "http://127.0.0.1:8080/v1/") else {
-            fatalError("Coult not create the base URL for the Xpense Server")
+            fatalError("Could not create the base URL for the Xpense Server")
         }
         return baseURL
     }()
@@ -26,9 +26,7 @@ public class RestfulModel: Model {
         do {
             try await saveElement(account, to: \.accounts)
         } catch {
-            DispatchQueue.main.async {
-                self.setServerError(to: .saveFailed(Account.self))
-            }
+            await setServerError(to: .saveFailed(Account.self))
             return
         }
         
@@ -39,9 +37,7 @@ public class RestfulModel: Model {
         do {
             try await saveElement(transaction, to: \.transactions)
         } catch {
-            DispatchQueue.main.async {
-                self.setServerError(to: .saveFailed(Transaction.self))
-            }
+            await setServerError(to: .saveFailed(Transaction.self))
             return
         }
         
@@ -52,9 +48,7 @@ public class RestfulModel: Model {
         do {
             try await delete(id, in: \.accounts)
         } catch {
-            DispatchQueue.main.async {
-                self.setServerError(to: .deleteFailed(Account.self))
-            }
+            await setServerError(to: .deleteFailed(Account.self))
             return
         }
         
@@ -65,9 +59,7 @@ public class RestfulModel: Model {
         do {
             try await delete(id, in: \.transactions)
         } catch {
-            DispatchQueue.main.async {
-                self.setServerError(to: .deleteFailed(Account.self))
-            }
+            await setServerError(to: .deleteFailed(Account.self))
             return
         }
         
@@ -78,7 +70,7 @@ public class RestfulModel: Model {
         do {
             try await sendSignUpRequest(name, password: password)
         } catch {
-            self.setServerError(to: .signUpFailed)
+            await setServerError(to: .signUpFailed)
             return
         }
         do {
@@ -93,39 +85,16 @@ public class RestfulModel: Model {
         do {
             try await sendLoginRequest(name, password: password)
         } catch {
-            self.setServerError(to: .loginFailed)
+            await setServerError(to: .loginFailed)
         }
         await refresh()
     }
-    
-    /// Sets the `serverError` of the `Model` and returns the error to be processed by `Publishers`
-    /// - Parameter error: The `XpenseServiceError` that should be set
-    /// - Returns: The `XpenseServiceError` passed in as an argument
-    func setServerError(to error: XpenseServiceError) {
-        DispatchQueue.main.async {
-            self.serverError = error
-        }
+
+    public override func refreshAccounts() async throws -> [Account] {
+        try await Account.get()
     }
-    
-    /// Refreshes the `Accounts` and `Transaction` in the `Model`
-    private func refresh() async {
-        do {
-            let accounts = try await Account.get()
-            DispatchQueue.main.async {
-                self.accounts = accounts
-            }
-        } catch {
-            self.setServerError(to:.loadingFailed(Account.self))
-            return
-        }
-        
-        do {
-            let transactions = try await Transaction.get()
-            DispatchQueue.main.async {
-                self.transactions = transactions
-            }
-        } catch {
-            self.setServerError(to:.loadingFailed(Transaction.self))
-        }
+
+    public override func refreshTransactions() async throws -> [Transaction] {
+        try await Transaction.get()
     }
 }

--- a/XpenseModel/Sources/XpenseModel/RestfulModel/RestfulModel.swift
+++ b/XpenseModel/Sources/XpenseModel/RestfulModel/RestfulModel.swift
@@ -76,7 +76,7 @@ public class RestfulModel: Model {
         do {
             try await sendLoginRequest(name, password: password)
         } catch {
-            self.setServerError(to: .loginFailed)
+            await setServerError(to: .loginFailed)
         }
         await refresh()
     }

--- a/XpenseModel/Sources/XpenseModel/RestfulModel/RestfulModel.swift
+++ b/XpenseModel/Sources/XpenseModel/RestfulModel/RestfulModel.swift
@@ -90,11 +90,11 @@ public class RestfulModel: Model {
         await refresh()
     }
 
-    public override func refreshAccounts() async throws -> [Account] {
+    override func loadAccounts() async throws -> [Account] {
         try await Account.get()
     }
 
-    public override func refreshTransactions() async throws -> [Transaction] {
+    override func loadTransactions() async throws -> [Transaction] {
         try await Transaction.get()
     }
 }


### PR DESCRIPTION
## :recycle: Current situation

Currently the `refresh()` method is ...
* part of the `RestfulModel` subclass and ...
* not available in the UI (relevant if you want to utilise selective/lazy loading using the `.task(action:)` modifier).

## :bulb: Proposed solution

This PR addresses those points by ...
* splitting up Account and Transaction loading into separate methods and ...
* moving it into the `Model` base class.


We propose to include this in the base version of all Xpense App versions, as these are only minimal changes such that students rely on a streamlined version of the app.

## :heavy_plus_sign: Additional Information

The PR additionally fixes some typos and fixes some bugs (e.g. setServerError sometimes enqueued the property assignment twice onto the main DispatchQueue).

Further, the PR moves away from `DispatchQueue` based synchronisation to present more modern concurrency primitives to the students (we might discuss our general approach in this area in the coming meeting?).