### PR TITLE
Remove duplicate logout alert

### DIFF
--- a/Xpense/Main View/ContentCoordinator.swift
+++ b/Xpense/Main View/ContentCoordinator.swift
@@ -32,9 +32,7 @@ struct ContentCoordinator<Content: View>: View {
     }
     
     @StateObject var contentState = ContentState()
-    /// Indicates whether the alert asking to confirm the logout process should be displayed
-    @State private var presentUserAlert = false
-    
+
     init(content: @escaping (Binding<[ContentLink]>) -> Content, contentType: ContentLink) {
         self.content = content
         self.contentType = contentType
@@ -46,14 +44,11 @@ struct ContentCoordinator<Content: View>: View {
                 .navigationTitle(navigationTitle)
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
-                        UserButton(presentUserAlert: $presentUserAlert)
+                        UserButton()
                     }
                     ToolbarItem(placement: .primaryAction) {
                         addButton
                     }
-                }
-                .alert(isPresented: $presentUserAlert) {
-                    UserButton.createLogoutAlert(model)
                 }
                 .sheet(item: $contentState.presentedItem, content: sheetContent)
                 .navigationDestination(for: ContentLink.self) { contentLink in

--- a/Xpense/User Subsystem/User/UserButton.swift
+++ b/Xpense/User Subsystem/User/UserButton.swift
@@ -17,22 +17,19 @@ struct UserButton: View {
     @EnvironmentObject private var model: Model
     
     /// Indicates whether the alert asking to confirm the logout process should be displayed
-    @Binding var presentUserAlert: Bool
-    
+    @State private var presentUserAlert: Bool = false
     
     var body: some View {
         Button(action: { self.presentUserAlert = true }) {
             Image(systemName: "person.circle")
         }
             .alert(isPresented: $presentUserAlert) {
-                UserButton.createLogoutAlert(model)
+                logoutAlert
             }
     }
     
-    
     /// Creates the alert asking to confirm the logout process
-    /// - Parameter model: The model used for the logout process
-    static func createLogoutAlert(_ model: Model) -> Alert {
+    private var logoutAlert: Alert {
         let alertText: String = "You are logged in as \"\(model.user?.name ?? "")\""
         return Alert(title: Text("User Overview"),
                      message: Text(alertText),
@@ -44,10 +41,7 @@ struct UserButton: View {
 
 // MARK: - UserButton Previews
 struct UserButton_Previews: PreviewProvider {
-    @State private static var presentUserAlert = false
-    
-    
     static var previews: some View {
-        UserButton(presentUserAlert: $presentUserAlert)
+        UserButton()
     }
 }


### PR DESCRIPTION
Fixes #19.

Removes the `.alert` from `ContentCoordinator` and inlines the presentation `@State` property into `UserButton`.